### PR TITLE
Fixes sound playing in tvOS simulator but not device.

### DIFF
--- a/addons/ofxiOS/src/sound/AVSoundPlayer.m
+++ b/addons/ofxiOS/src/sound/AVSoundPlayer.m
@@ -38,11 +38,11 @@
     NSError * err = nil;
     // need to configure set the audio category, and override to it route the audio to the speaker
     if([audioSession respondsToSelector:@selector(setCategory:withOptions:error:)]) {
-        if(![audioSession setCategory:AVAudioSessionCategoryPlayAndRecord
+        if(![audioSession setCategory:AVAudioSessionCategoryPlayback
              						  withOptions:AVAudioSessionCategoryOptionMixWithOthers
                                         error:&err]) { err = nil; }
     }
-	[[AVAudioSession sharedInstance] setActive: YES error: nil];
+	[[AVAudioSession sharedInstance] setActive: YES error: nil];	
 	audioSessionSetup = YES;
 }
 


### PR DESCRIPTION
tvOS doesn't support AVAudioSessionCategoryPlayAndRecord but the simulator does, leading to sounds playing in the sim but not the device. Changing this to AVAudioSessionCategoryPlayback in AVSoundPlayer. Can't see an instance when AVSoundPlayer should need input.
